### PR TITLE
Added option to disable imap-auth for login

### DIFF
--- a/install-piler.sh
+++ b/install-piler.sh
@@ -151,7 +151,7 @@ if [ ! -f $installPth/.configDone ]; then
 
     # IMAP Server
     while true; do
-        read -ep "Do you want to use IMAP Auth? " jn
+        read -ep "Do you want to use IMAP Auth? (y/n): " jn
         case $jn in
             [Yy]* ) sed -i 's/USE_IMAPAUTH=.*/USE_IMAPAUTH=true/g' ./piler.conf;
             read -ep "Please set your IMAP Server (Enter for default: $IMAP_SERVER): " imapServer

--- a/install-piler.sh
+++ b/install-piler.sh
@@ -151,7 +151,7 @@ if [ ! -f $installPth/.configDone ]; then
 
     # IMAP Server
     while true; do
-        read -ep "Do you want to use IMAP Auth? (y/n): " jn
+        read -ep "Do you want to use IMAP Auth? (y/n) (Default: yes): " jn
         case $jn in
             [Yy]* ) sed -i 's/USE_IMAPAUTH=.*/USE_IMAPAUTH=true/g' ./piler.conf;
             read -ep "Please set your IMAP Server (Enter for default: $IMAP_SERVER): " imapServer
@@ -159,7 +159,11 @@ if [ ! -f $installPth/.configDone ]; then
             sed -i 's/IMAP_SERVER=.*/IMAP_SERVER="'$imapServer'"/g' ./piler.conf
             break;;
             [Nn]* ) sed -i 's/USE_IMAPAUTH=.*/USE_IMAPAUTH=false/g' ./piler.conf; break;;
-            * ) echo -e "${redBold} Please confirm with Y or N.${normal}";;
+            * ) sed -i 's/USE_IMAPAUTH=.*/USE_IMAPAUTH=true/g' ./piler.conf;
+            read -ep "Please set your IMAP Server (Enter for default: $IMAP_SERVER): " imapServer
+            imapServer=${imapServer:=$IMAP_SERVER}
+            sed -i 's/IMAP_SERVER=.*/IMAP_SERVER="'$imapServer'"/g' ./piler.conf
+            break;;
         esac
     done
 
@@ -187,7 +191,7 @@ if [ ! -f $installPth/.configDone ]; then
 
     # use Let's Encrypt
     while true; do
-        read -ep "Enabled / Disabled (yes/no) Let's Encrypt? For local Run disabled / Y|N: " jn
+        read -ep "Do you want to use Let's Encrypt? For local Run disabled / (y/n): " jn
         case $jn in
             [Yy]* ) sed -i 's/USE_LETSENCRYPT=.*/USE_LETSENCRYPT="yes"/g' ./piler.conf; break;;
             [Nn]* ) sed -i 's/USE_LETSENCRYPT=.*/USE_LETSENCRYPT="no"/g' ./piler.conf; break;;
@@ -207,7 +211,7 @@ if [ ! -f $installPth/.configDone ]; then
 
     # use Mailcow
     while true; do
-        read -ep "If Use Mailcow API Options (yes/no)? / Y|N: " jn
+        read -ep "If Use Mailcow API Options (yes/no)? / (y/n): " jn
         case $jn in
             [Yy]* ) sed -i 's/USE_MAILCOW=.*/USE_MAILCOW=true/g' ./piler.conf; break;;
             [Nn]* ) sed -i 's/USE_MAILCOW=.*/USE_MAILCOW=false/g' ./piler.conf; break;;
@@ -232,7 +236,7 @@ if [ ! -f $installPth/.configDone ]; then
 
     # Import Interval Settings 
     while true; do
-        read -ep "If Use automatic import to 5 minutes interval (yes/no)? / Y|N (Default: no): " jn
+        read -ep "If Use automatic import to 5 minutes interval? / (y/n) (Default: no): " jn
         case $jn in
             [Yy]* ) sed -i 's/AUTO_IMPORT=.*/AUTO_IMPORT=true/g' ./piler.conf; break;;
             [Nn]* ) sed -i 's/AUTO_IMPORT=.*/AUTO_IMPORT=false/g' ./piler.conf; break;;
@@ -291,7 +295,7 @@ done
 
 # start piler install
 while true; do
-    read -ep "Do you want to start the Piler installation now? / Y|N: " yn
+    read -ep "Do you want to start the Piler installation now? / (y/n): " yn
     case $yn in
         [Yy]* ) echo -e "${greenBold}Piler install started!! ${normal}"; break;;
         [Nn]* ) echo -e "${redBold}Aborting the Piler installation!! ${normal}"; exit;;

--- a/patch.sh
+++ b/patch.sh
@@ -137,16 +137,6 @@ cat >> $configSite <<EOF
 // general settings.
 \$config['TIMEZONE'] = '$TIME_ZONE';
 
-// authentication
-// Enable authentication against an imap server
-\$config['ENABLE_IMAP_AUTH'] = 1;
-\$config['RESTORE_OVER_IMAP'] = 1;
-\$config['IMAP_RESTORE_FOLDER_INBOX'] = 'INBOX';
-\$config['IMAP_RESTORE_FOLDER_SENT'] = 'Sent';
-\$config['IMAP_HOST'] = '$IMAP_SERVER';
-\$config['IMAP_PORT'] =  993;
-\$config['IMAP_SSL'] = true;
-
 // authentication against an ldap directory (disabled by default)
 //\$config['ENABLE_LDAP_AUTH'] = 1;
 //\$config['LDAP_HOST'] = '$SMARTHOST';
@@ -180,6 +170,23 @@ EOF
 
 echo "Patch config-site.php with your Settings"
 fi
+
+
+if [ "$USE_IMAPAUTH" = true ]; then
+cat >> $configSite <<EOF
+
+// authentication
+// Enable authentication against an imap server
+\$config['ENABLE_IMAP_AUTH'] = 1;
+\$config['RESTORE_OVER_IMAP'] = 1;
+\$config['IMAP_RESTORE_FOLDER_INBOX'] = 'INBOX';
+\$config['IMAP_RESTORE_FOLDER_SENT'] = 'Sent';
+\$config['IMAP_HOST'] = '$IMAP_SERVER';
+\$config['IMAP_PORT'] =  993;
+\$config['IMAP_SSL'] = true;
+EOF
+fi
+
 
 if [ "$USE_MAILCOW" = true ]; then
 

--- a/piler.conf.example
+++ b/piler.conf.example
@@ -14,6 +14,8 @@ DEFAULT_RETENTION_DAYS="2555"
 
 # your IMAP Server
 
+USE_IMAPAUTH=true
+
 IMAP_SERVER="imap.example.com"
 
 # your Timezone

--- a/update.sh
+++ b/update.sh
@@ -135,7 +135,7 @@ fi
 #######################################################################################
 
 while true; do
-    read -ep "Do you want to perform the update?? (y/n): " yn
+    read -ep "Do you want to perform the update? (y/n): " yn
     case $yn in
         [Yy]* ) echo "${greenBold}********* Update started... Please wait... *********${normal}"; break;;
         [Nn]* ) echo -e "${redBold}    The update is canceled!${normal}"; exit;;
@@ -290,7 +290,7 @@ echo "${greenBold}${HLINE}${normal}"
 echo
 
 while true; do
-    read -ep "Do you want to perform the Reindex?? (y/n): " yn
+    read -ep "Do you want to perform the Reindex? (y/n): " yn
     case $yn in
         [Yy]* ) echo "${greenBold}********* Reindex started... Please wait... *********${normal}"; break;;
         [Nn]* ) echo -e "${redBold}    Update without Reindex!${normal}"; finish_info;;


### PR DESCRIPTION
Workaround for very specific problem as described in #17 

Added new option set to enable/disable imap-auth in installer/patch using new var USE_IMAPAUTH

Double tested on a ubuntu 22.04 vm. with yes/no.