### PR TITLE
compose: fix healthcheck of mariadb

### DIFF
--- a/config/piler-default.yml
+++ b/config/piler-default.yml
@@ -21,7 +21,7 @@ services:
       - MARIADB_DISABLE_UPGRADE_BACKUP=1
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     healthcheck:
-      test: mysql --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} piler --execute "show tables"
+      test: mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} piler --execute "show tables"
       interval: "60s"
       timeout: "5s"
       start_period: "15s"

--- a/config/piler-ssl.yml
+++ b/config/piler-ssl.yml
@@ -49,7 +49,7 @@ services:
       - MARIADB_DISABLE_UPGRADE_BACKUP=1
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     healthcheck:
-      test: mysql --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} piler --execute "show tables"
+      test: mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} piler --execute "show tables"
       interval: "60s"
       timeout: "5s"
       start_period: "15s"


### PR DESCRIPTION
mariadb 11.X removed the mysql command and is now using the mariadb command instead.

This PR changes the behavior of the healthcheck inside compose.yml accordingly.

The mysql command was a symlink beginning with 10.5 to mariadb command (see https://mariadb.com/kb/en/changes-and-improvements-in-mariadb-10-5/#binaries-named-mariadb-mysql-symlinked)

Without that PR the healthcheck of mysql/maridb is not gonna be healthy on versions 11.X.